### PR TITLE
Initial commit of Bloomreach Cloud specific virtual host configurations (cms/site)

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/hst/hosts/dev-brc-cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/hosts/dev-brc-cms.yaml
@@ -1,0 +1,5 @@
+definitions:
+  config:
+    /hst:platform/hst:hosts/dev-brc-cms:
+      jcr:primaryType: hst:virtualhostgroup
+      hst:defaultport: 80

--- a/repository-data/application/src/main/resources/hcm-config/hst/hosts/dev-brc-cms/uk.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/hosts/dev-brc-cms/uk.yaml
@@ -1,0 +1,19 @@
+definitions:
+  config:
+    /hst:platform/hst:hosts/dev-brc-cms/uk:
+      jcr:primaryType: hst:virtualhost
+      hst:scheme: https
+      hst:showcontextpath: false
+      hst:showport: false
+      /nhs:
+        jcr:primaryType: hst:virtualhost
+        /hee:
+          jcr:primaryType: hst:virtualhost
+          /dev:
+            jcr:primaryType: hst:virtualhost
+            /cms:
+              jcr:primaryType: hst:virtualhost
+              /hst:root:
+                jcr:primaryType: hst:mount
+                hst:ismapped: false
+                hst:namedpipeline: WebApplicationInvokingPipeline

--- a/repository-data/application/src/main/resources/hcm-config/hst/hosts/prd-brc-cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/hosts/prd-brc-cms.yaml
@@ -1,0 +1,5 @@
+definitions:
+  config:
+    /hst:platform/hst:hosts/prd-brc-cms:
+      jcr:primaryType: hst:virtualhostgroup
+      hst:defaultport: 80

--- a/repository-data/application/src/main/resources/hcm-config/hst/hosts/prd-brc-cms/uk.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/hosts/prd-brc-cms/uk.yaml
@@ -1,0 +1,17 @@
+definitions:
+  config:
+    /hst:platform/hst:hosts/prd-brc-cms/uk:
+      jcr:primaryType: hst:virtualhost
+      hst:scheme: https
+      hst:showcontextpath: false
+      hst:showport: false
+      /nhs:
+        jcr:primaryType: hst:virtualhost
+        /hee:
+          jcr:primaryType: hst:virtualhost
+          /cms:
+            jcr:primaryType: hst:virtualhost
+            /hst:root:
+              jcr:primaryType: hst:mount
+              hst:ismapped: false
+              hst:namedpipeline: WebApplicationInvokingPipeline

--- a/repository-data/application/src/main/resources/hcm-config/hst/hosts/stg-brc-cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/hosts/stg-brc-cms.yaml
@@ -1,0 +1,5 @@
+definitions:
+  config:
+    /hst:platform/hst:hosts/stg-brc-cms:
+      jcr:primaryType: hst:virtualhostgroup
+      hst:defaultport: 80

--- a/repository-data/application/src/main/resources/hcm-config/hst/hosts/stg-brc-cms/uk.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/hosts/stg-brc-cms/uk.yaml
@@ -1,0 +1,19 @@
+definitions:
+  config:
+    /hst:platform/hst:hosts/stg-brc-cms/uk:
+      jcr:primaryType: hst:virtualhost
+      hst:scheme: https
+      hst:showcontextpath: false
+      hst:showport: false
+      /nhs:
+        jcr:primaryType: hst:virtualhost
+        /hee:
+          jcr:primaryType: hst:virtualhost
+          /stg:
+            jcr:primaryType: hst:virtualhost
+            /cms:
+              jcr:primaryType: hst:virtualhost
+              /hst:root:
+                jcr:primaryType: hst:mount
+                hst:ismapped: false
+                hst:namedpipeline: WebApplicationInvokingPipeline

--- a/repository-data/application/src/main/resources/hcm-config/hst/hosts/tst-brc-cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/hosts/tst-brc-cms.yaml
@@ -1,0 +1,5 @@
+definitions:
+  config:
+    /hst:platform/hst:hosts/tst-brc-cms:
+      jcr:primaryType: hst:virtualhostgroup
+      hst:defaultport: 80

--- a/repository-data/application/src/main/resources/hcm-config/hst/hosts/tst-brc-cms/uk.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/hosts/tst-brc-cms/uk.yaml
@@ -1,0 +1,19 @@
+definitions:
+  config:
+    /hst:platform/hst:hosts/tst-brc-cms/uk:
+      jcr:primaryType: hst:virtualhost
+      hst:scheme: https
+      hst:showcontextpath: false
+      hst:showport: false
+      /nhs:
+        jcr:primaryType: hst:virtualhost
+        /hee:
+          jcr:primaryType: hst:virtualhost
+          /tst:
+            jcr:primaryType: hst:virtualhost
+            /cms:
+              jcr:primaryType: hst:virtualhost
+              /hst:root:
+                jcr:primaryType: hst:mount
+                hst:ismapped: false
+                hst:namedpipeline: WebApplicationInvokingPipeline

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/dev-brc-site.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/dev-brc-site.yaml
@@ -1,0 +1,6 @@
+definitions:
+  config:
+    /hst:hst/hst:hosts/dev-brc-site:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:virtualhostgroup
+      hst:defaultport: 80

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/dev-brc-site/uk.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/dev-brc-site/uk.yaml
@@ -1,0 +1,25 @@
+definitions:
+  config:
+    /hst:hst/hst:hosts/dev-brc-site/uk:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:virtualhost
+      hst:scheme: https
+      hst:showcontextpath: false
+      hst:showport: false
+      /nhs:
+        .meta:residual-child-node-category: content
+        jcr:primaryType: hst:virtualhost
+        /hee:
+          .meta:residual-child-node-category: content
+          jcr:primaryType: hst:virtualhost
+          /dev:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:virtualhost
+            /www:
+              .meta:residual-child-node-category: content
+              jcr:primaryType: hst:virtualhost
+              /hst:root:
+                .meta:residual-child-node-category: content
+                jcr:primaryType: hst:mount
+                hst:homepage: root
+                hst:mountpoint: /hst:heeweb/hst:sites/heeweb

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brc-site.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brc-site.yaml
@@ -1,0 +1,6 @@
+definitions:
+  config:
+    /hst:hst/hst:hosts/prd-brc-site:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:virtualhostgroup
+      hst:defaultport: 80

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brc-site/uk.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd-brc-site/uk.yaml
@@ -1,0 +1,22 @@
+definitions:
+  config:
+    /hst:hst/hst:hosts/prd-brc-site/uk:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:virtualhost
+      hst:scheme: https
+      hst:showcontextpath: false
+      hst:showport: false
+      /nhs:
+        .meta:residual-child-node-category: content
+        jcr:primaryType: hst:virtualhost
+        /hee:
+          .meta:residual-child-node-category: content
+          jcr:primaryType: hst:virtualhost
+          /www:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:virtualhost
+            /hst:root:
+              .meta:residual-child-node-category: content
+              jcr:primaryType: hst:mount
+              hst:homepage: root
+              hst:mountpoint: /hst:heeweb/hst:sites/heeweb

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/stg-brc-site.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/stg-brc-site.yaml
@@ -1,0 +1,6 @@
+definitions:
+  config:
+    /hst:hst/hst:hosts/stg-brc-site:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:virtualhostgroup
+      hst:defaultport: 80

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/stg-brc-site/uk.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/stg-brc-site/uk.yaml
@@ -1,0 +1,25 @@
+definitions:
+  config:
+    /hst:hst/hst:hosts/stg-brc-site/uk:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:virtualhost
+      hst:scheme: https
+      hst:showcontextpath: false
+      hst:showport: false
+      /nhs:
+        .meta:residual-child-node-category: content
+        jcr:primaryType: hst:virtualhost
+        /hee:
+          .meta:residual-child-node-category: content
+          jcr:primaryType: hst:virtualhost
+          /stg:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:virtualhost
+            /www:
+              .meta:residual-child-node-category: content
+              jcr:primaryType: hst:virtualhost
+              /hst:root:
+                .meta:residual-child-node-category: content
+                jcr:primaryType: hst:mount
+                hst:homepage: root
+                hst:mountpoint: /hst:heeweb/hst:sites/heeweb

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/tst-brc-site.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/tst-brc-site.yaml
@@ -1,0 +1,6 @@
+definitions:
+  config:
+    /hst:hst/hst:hosts/tst-brc-site:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:virtualhostgroup
+      hst:defaultport: 80

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/tst-brc-site/uk.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/tst-brc-site/uk.yaml
@@ -1,0 +1,25 @@
+definitions:
+  config:
+    /hst:hst/hst:hosts/tst-brc-site/uk:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:virtualhost
+      hst:scheme: https
+      hst:showcontextpath: false
+      hst:showport: false
+      /nhs:
+        .meta:residual-child-node-category: content
+        jcr:primaryType: hst:virtualhost
+        /hee:
+          .meta:residual-child-node-category: content
+          jcr:primaryType: hst:virtualhost
+          /tst:
+            .meta:residual-child-node-category: content
+            jcr:primaryType: hst:virtualhost
+            /www:
+              .meta:residual-child-node-category: content
+              jcr:primaryType: hst:virtualhost
+              /hst:root:
+                .meta:residual-child-node-category: content
+                jcr:primaryType: hst:mount
+                hst:homepage: root
+                hst:mountpoint: /hst:heeweb/hst:sites/heeweb


### PR DESCRIPTION
Virtual Hosts are created for Bloomreach Cloud dev/tst/stg/prd environments assuming the following domains:
- dev-brc-cms: https://cms.dev.hee.nhs.uk
- dev-brc-site: https://www.dev.hee.nhs.uk
- tst-brc-cms: https://cms.tst.hee.nhs.uk
- tst-brc-site: https://www.tst.hee.nhs.uk
- stg-brc-cms: https://cms.stg.hee.nhs.uk
- stg-brc-site: https://www.stg.hee.nhs.uk
- prd-brc-cms: https://cms.hee.nhs.uk
- prd-brc-site: https://www.hee.nhs.uk

Note that the above environments/domain assumption might change a bit based on the deployment strategy (blue/green or stop-start/rolling update) that would be chosen.

Also, we would need to share the SSL certificates for the above domains with Bloomreach Cloud support team when available so that they could configure it on the stack.