### PR TITLE
Enabling bloomreach delivery tier JAAS authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,9 @@ storage
 ## Node
 ##############################
 node_modules
+
+##############################
+## HotswapAgent
+##############################
+hotswap-agent/**
+**/hotswap-agent.properties

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/default/sitemap.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/default/sitemap.yaml
@@ -1,0 +1,4 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/hst:default/hst:sitemap/login:
+      hst:scheme: http

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts.yaml
@@ -12,3 +12,5 @@ definitions:
           jcr:primaryType: hst:mount
           hst:homepage: root
           hst:mountpoint: /hst:heeweb/hst:sites/heeweb
+          hst:roles: [everybody]
+          hst:authenticated: true


### PR DESCRIPTION
- Enabled `login` SiteMapItem to use `http` scheme
- Enable OOTB delivery tier JAAS authentication at the mount level for `everybody` role i.e. for all authenticated users.