### PR TITLE
Disabling Algolia Search Service Integration specific routes and services (temporarily)

### DIFF
--- a/cms/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/cms/src/main/webapp/WEB-INF/applicationContext.xml
@@ -21,5 +21,5 @@
                       http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
                       http://camel.apache.org/schema/spring
                       http://camel.apache.org/schema/spring/camel-spring.xsd">
-  <import resource="/camel/routes.xml" />
+  <!-- <import resource="/camel/routes.xml" /> -->
 </beans>

--- a/site/components/src/main/resources/META-INF/hst-assembly/overrides/custom-jaxrs-resources.xml
+++ b/site/components/src/main/resources/META-INF/hst-assembly/overrides/custom-jaxrs-resources.xml
@@ -19,7 +19,7 @@
 
     <!-- Your custom JAX-RS REST Plain Resource Providers will be added into
          the following list !!! -->
-    <bean id="customRestPlainResourceProviders"
+    <!-- <bean id="customRestPlainResourceProviders"
           class="org.springframework.beans.factory.config.ListFactoryBean">
         <property name="sourceList">
             <list>
@@ -34,7 +34,7 @@
                 </bean>
             </list>
         </property>
-    </bean>
+    </bean> -->
 
     <!-- Your custom JAX-RS REST Content/Context Aware Resource Providers
          will be added into the following list !!! -->


### PR DESCRIPTION
Disabling temporarily in order to start **site** webapp without Algolia _applicationId_ and _apiKey_